### PR TITLE
Migrate cronjob manifest to batch/v1

### DIFF
--- a/charts/aws-ecr-credential/templates/cron.yaml
+++ b/charts/aws-ecr-credential/templates/cron.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ include "aws-ecr-credential.cronJob" . }}


### PR DESCRIPTION
The batch/v1beta1 API version of CronJob[ is no longer served as of v1.25](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#cronjob-v125). So we might need to move the API to the newer version batch/v1